### PR TITLE
Change "mode" to "modes".

### DIFF
--- a/flycheck-typescript.el
+++ b/flycheck-typescript.el
@@ -33,7 +33,7 @@
   :command ("tsc" "--out" "/dev/null" source)
   :error-patterns
   ((error line-start (file-name) "(" line "," column "): error " (message) line-end))
-  :mode typescript-mode)
+  :modes (typescript-mode))
 
 (add-to-list 'flycheck-checkers 'typescript)
 


### PR DESCRIPTION
When `:mode` keyword was used, `typescript` checker was enabled for other opened buffers, so I was getting:
_Suspicious state from syntax checker typescript [...]_. 
